### PR TITLE
Update Translation Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 ## Translation Notes
 
-A file with highlighting to show what to translate and what to change is at: https://docs.google.com/document/d/1oVOIXH5mVvJSmznyWVU4A4N7E6vCOeHvYbpdAJvpbU0/edit
-
 **Check if the [player is available in your translated language](https://github.com/ableplayer/ableplayer/blob/master/README.md#user-content-supported-languages).**
 
 * **If the _is_ available in the translated language**, the player will automatically switch to the language. Therefore, you should translate the words from the video player interface. Please also update the image per the instructions below.<br>_If you are not able to update the image, let us know._
@@ -22,8 +20,7 @@ A file with highlighting to show what to translate and what to change is at: htt
      * "Show transcript"
      * "Language"
    * Mark up the English words with the language attribute: "`<span lang="en">Captions</span>`".
-   
-   
+
 ### Footer update April 2019
 
-[GitHub Diff](https://github.com/w3c/wai-video-standards-and-benefits/commit/e1f94d20042b9b60d1cda02c5bb58cbedf9acee8#diff-d680e8a854a7cbad6d490c445cba2eba) of footer changes. [Google doc](https://docs.google.com/document/d/1oVOIXH5mVvJSmznyWVU4A4N7E6vCOeHvYbpdAJvpbU0/edit#bookmark=id.ddeb6zwckwat) has highlighting to show which words to translate, and which to leave in English (organization names and project titles).
+[GitHub Diff](https://github.com/w3c/wai-video-standards-and-benefits/commit/e1f94d20042b9b60d1cda02c5bb58cbedf9acee8#diff-d680e8a854a7cbad6d490c445cba2eba) of footer changes.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,27 @@
 
 ## Translation Notes
 
-**Check if the [player is available in your translated language](https://github.com/ableplayer/ableplayer/blob/master/README.md#user-content-supported-languages).**
+1. Check if the [player is available in your translated language](https://github.com/ableplayer/ableplayer/blob/master/README.md#user-content-supported-languages).
 
-* **If the player _is_ available in the translated language**, the player will automatically switch to the language. Therefore, you should translate the words from the video player interface. Please also update the image per the instructions below.<br>_If you are not able to update the image, let us know._
-   * Make a new image to replace https://www.w3.org/WAI/content-images/wai-video-standards-and-benefits/show-language.png The circle is  7px #eed009 / rgb(238,208,9).
-   * Name it show-language.[language code].png for example: `show-language.fr.png`
-   * Upload it to the [content-images folder](https://github.com/w3c/wai-video-standards-and-benefits/tree/master/content-images/wai-video-standards-and-benefits)
-      * Select "Upload files"
-      * Drag or choose the file
-      * Select "Commit changes"
-   * In your translation, add the language code to the image name.
-* **If the player is _not_ available in the translated language**, under the "Translations" heading:
+2. Translate the "Translations" section of the page accordingly:
+* **If the player _is_ available in the translated language**:
+  * Translate the following words from the video player interface:
+    * "Captions"
+    * "Show transcript"
+    * "Language"
+  * Please also update the image per the instructions below.<br>_If you are not able to update the image, let us know._
+     * Make a new image to replace [show-language.png](https://www.w3.org/WAI/content-images/wai-video-standards-and-benefits/show-language.png). The circle is 7px #eed009 / rgb(238,208,9).
+     * Name it `show-language.[language shortcode].png`\
+    For example: `show-language.fr.png`
+     * Upload it to the [content-images folder](https://github.com/w3c/wai-video-standards-and-benefits/tree/master/content-images/wai-video-standards-and-benefits)
+        * Select "Upload files"
+        * Drag or choose the file
+        * Select "Commit changes"
+     * In your translation, add the language shortcode to the image path.
+* **If the player is _not_ available in the translated language**:
    * Do not translate the following words from the video player interface; leave them in English:
      * "Captions"
      * "Show transcript"
      * "Language"
-   * Mark up the English words with the language attribute: "`<span lang="en">Captions</span>`".
+   * Mark up the English words with the lang attribute:\
+  `<span lang="en">Captions</span>`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Check if the [player is available in your translated language](https://github.com/ableplayer/ableplayer/blob/master/README.md#user-content-supported-languages).**
 
-* **If the _is_ available in the translated language**, the player will automatically switch to the language. Therefore, you should translate the words from the video player interface. Please also update the image per the instructions below.<br>_If you are not able to update the image, let us know._
+* **If the player _is_ available in the translated language**, the player will automatically switch to the language. Therefore, you should translate the words from the video player interface. Please also update the image per the instructions below.<br>_If you are not able to update the image, let us know._
    * Make a new image to replace https://www.w3.org/WAI/content-images/wai-video-standards-and-benefits/show-language.png The circle is  7px #eed009 / rgb(238,208,9).
    * Name it show-language.[language code].png for example: `show-language.fr.png`
    * Upload it to the [content-images folder](https://github.com/w3c/wai-video-standards-and-benefits/tree/master/content-images/wai-video-standards-and-benefits)
@@ -20,7 +20,3 @@
      * "Show transcript"
      * "Language"
    * Mark up the English words with the language attribute: "`<span lang="en">Captions</span>`".
-
-### Footer update April 2019
-
-[GitHub Diff](https://github.com/w3c/wai-video-standards-and-benefits/commit/e1f94d20042b9b60d1cda02c5bb58cbedf9acee8#diff-d680e8a854a7cbad6d490c445cba2eba) of footer changes.


### PR DESCRIPTION
- Delete links to Google Docs
- Delete reference to 2019 footer update (all translations have been updated since)
- Update instructions.